### PR TITLE
Add sandbox flag

### DIFF
--- a/Keelhaul/Core/Keelhaul.swift
+++ b/Keelhaul/Core/Keelhaul.swift
@@ -69,10 +69,13 @@ public final class Keelhaul {
 
   public init(token: String,
     receiptURL: NSURL? = NSBundle.mainBundle().appStoreReceiptURL,
-    endpointURL: NSURL = NSURL(string: "https://keelhaul.thoughtbot.com/api/v1/validate")!) {
+    endpointURL: NSURL = NSURL(string: "https://keelhaul.thoughtbot.com/api/v1/validate")!,
+    useSandbox: Bool = false) {
+      let components = NSURLComponents(URL: endpointURL, resolvingAgainstBaseURL: false)
+      components!.queryItems = [NSURLQueryItem(name: "sandbox", value: useSandbox ? "1" : "0")]
       self.token = token
       self.receiptURL = receiptURL
-      self.endpointURL = endpointURL
+      self.endpointURL = components!.URL!
   }
 
   public final func validateReceipt(completion: (Receipt?, NSError?) -> Void) {


### PR DESCRIPTION
- This allows the developer to choose if they want to use the sandbox
environment or not without manually constructing the URL.